### PR TITLE
Expand PyMuPDF4LLM configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,18 +79,28 @@ loader = PyMuPDF4LLMLoader(
     ##     max_tokens=1024
     ## )),
 
-    # Table extraction strategy to use. Options are
-    # "lines_strict", "lines", or "text". "lines_strict" is the default
-    # strategy and is the most accurate for tables with column and row lines,
-    # but may not work well with all documents.
-    # "lines" is a less strict strategy that may work better with
-    # some documents.
-    # "text" is the least strict strategy and may work better
-    # with documents that do not have tables with lines.
-    ## table_strategy="lines",
-
-    # Mono-spaced text will not be parsed as code blocks
-    ## ignore_code=True
+    # Additional keyword arguments to pass directly to the
+    # underlying `pymupdf4llm.to_markdown` function.
+    # See the `pymupdf4llm` documentation for available options.
+    # Note that certain arguments (`ignore_images`, `ignore_graphics`,
+    # `write_images`, `embed_images`, `image_path`, `filename`,
+    # `page_chunks`, `extract_words`, `show_progress`) cannot be used as
+    # they conflict with the loader's internal logic.
+    # Example:
+    # **{
+    #     # Table extraction strategy to use. Options are
+    #     # "lines_strict", "lines", or "text". "lines_strict" is the default
+    #     # strategy and is the most accurate for tables with column and row lines,
+    #     # but may not work well with all documents.
+    #     # "lines" is a less strict strategy that may work better with
+    #     # some documents.
+    #     # "text" is the least strict strategy and may work better
+    #     # with documents that do not have tables with lines.
+    #     "table_strategy": "lines",
+    #
+    #     # Mono-spaced text will not be parsed as code blocks
+    #     "ignore_code": True,
+    # }
 )
 ```
 

--- a/tests/unit_tests/test_pymupdf4llm_parser.py
+++ b/tests/unit_tests/test_pymupdf4llm_parser.py
@@ -46,3 +46,60 @@ def test_pymupdf4llm_parser_modes(
     metadata = docs[0].metadata
     assert isinstance(metadata, dict)
     assert metadata["source"] == str(doc_path)
+
+
+def test_invalid_mode():
+    """Test that an invalid mode raises ValueError."""
+    with pytest.raises(ValueError, match="mode must be single or page"):
+        PyMuPDF4LLMParser(mode="invalid_mode")
+
+
+def test_missing_images_parser():
+    """Test that ValueError is raised if extract_images is True but no images_parser."""
+    with pytest.raises(
+        ValueError, match="images_parser must be provided if extract_images is True"
+    ):
+        PyMuPDF4LLMParser(extract_images=True)
+
+
+@pytest.mark.parametrize(
+    "conflicting_kwarg",
+    [
+        "ignore_images",
+        "ignore_graphics",
+    ],
+)
+def test_conflicting_image_kwargs(conflicting_kwarg: str):
+    """Test conflicting image-related kwargs raise ValueError when extract_images=True."""
+    # A dummy parser is needed, even if not used, to satisfy the images_parser requirement
+    class DummyParser:
+        pass
+
+    kwargs = {conflicting_kwarg: True}
+    with pytest.raises(
+        ValueError,
+        match=f"PyMuPDF4LLM argument: {conflicting_kwarg} cannot be set to True when extract_images is True.",
+    ):
+        PyMuPDF4LLMParser(extract_images=True, images_parser=DummyParser(), **kwargs)
+
+
+@pytest.mark.parametrize(
+    "unsupported_kwarg",
+    [
+        "write_images",
+        "embed_images",
+        "image_path",
+        "filename",
+        "page_chunks",
+        "extract_words",
+        "show_progress",
+    ],
+)
+def test_unsupported_kwargs(unsupported_kwarg: str):
+    """Test that unsupported pymupdf4llm_kwargs raise ValueError."""
+    kwargs = {unsupported_kwarg: True}  # The value doesn't matter, just its presence
+    with pytest.raises(
+        ValueError,
+        match=f"PyMuPDF4LLM argument: {unsupported_kwarg} cannot be set to True.",
+    ):
+        PyMuPDF4LLMParser(**kwargs)

--- a/tests/unit_tests/test_pymupdf4llm_parser.py
+++ b/tests/unit_tests/test_pymupdf4llm_parser.py
@@ -103,3 +103,20 @@ def test_unsupported_kwargs(unsupported_kwarg: str):
         match=f"PyMuPDF4LLM argument: {unsupported_kwarg} cannot be set to True.",
     ):
         PyMuPDF4LLMParser(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "valid_kwarg_key, valid_kwarg_value",
+    [
+        ("table_strategy", "lines"),
+        ("ignore_code", True),
+        # Add other known valid kwargs if needed
+    ],
+)
+def test_valid_pymupdf4llm_kwargs(valid_kwarg_key: str, valid_kwarg_value):
+    """Test that valid pymupdf4llm_kwargs do not raise errors during init."""
+    kwargs = {valid_kwarg_key: valid_kwarg_value}
+    try:
+        PyMuPDF4LLMParser(**kwargs)
+    except ValueError as e:
+        pytest.fail(f"Initialization failed unexpectedly with valid kwarg: {e}")


### PR DESCRIPTION
This pull request refactors the `PyMuPDF4LLM` loader and parser to enhance flexibility by replacing specific parameters with a general `**pymupdf4llm_kwargs` mechanism for passing additional arguments. It also introduces stricter validation for unsupported or conflicting arguments and updates the documentation and tests accordingly.

### Refactoring for Enhanced Flexibility:
* Replaced specific parameters like `table_strategy` and `ignore_code` with a generic `**pymupdf4llm_kwargs` in the `__init__` methods of `PyMuPDF4LLMLoader` and `PyMuPDF4LLMParser` to allow passing additional keyword arguments directly to the `pymupdf4llm.to_markdown` function. [[1]](diffhunk://#diff-7b0fad3d985a5bb820b39f6cfc94d945cd01d45c46dae172ce56d4526327f701R178-R184) [[2]](diffhunk://#diff-f79581bfc327c6794eccf59bcadd27ee43f56a2baf590dbe237cbaad4424553dL153-R153)
* Updated the `pymupdf4llm.to_markdown` call to include `**pymupdf4llm_kwargs` for dynamic configuration. [[1]](diffhunk://#diff-f79581bfc327c6794eccf59bcadd27ee43f56a2baf590dbe237cbaad4424553dL271-R306) [[2]](diffhunk://#diff-f79581bfc327c6794eccf59bcadd27ee43f56a2baf590dbe237cbaad4424553dR317-L288)

### Validation Improvements:
* Added checks to raise `ValueError` for unsupported or conflicting `pymupdf4llm_kwargs` such as `ignore_images`, `write_images`, and `page_chunks`. This ensures compatibility with the loader and parser's internal logic. [[1]](diffhunk://#diff-7b0fad3d985a5bb820b39f6cfc94d945cd01d45c46dae172ce56d4526327f701L218-R226) [[2]](diffhunk://#diff-f79581bfc327c6794eccf59bcadd27ee43f56a2baf590dbe237cbaad4424553dL164-R225)

### Documentation Updates:
* Updated the `README.md` and docstrings to reflect the new `**pymupdf4llm_kwargs` mechanism and provide examples of valid and invalid arguments. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L82-R103) [[2]](diffhunk://#diff-7b0fad3d985a5bb820b39f6cfc94d945cd01d45c46dae172ce56d4526327f701L198-R207) [[3]](diffhunk://#diff-f79581bfc327c6794eccf59bcadd27ee43f56a2baf590dbe237cbaad4424553dL164-R225)

### Test Enhancements:
* Added unit tests to verify:
  - Proper handling of valid `pymupdf4llm_kwargs`.
  - Errors for unsupported or conflicting arguments, such as `extract_images` without `images_parser`.
  - Validation of invalid modes and unsupported keyword arguments.