### PR TITLE
feat: add on_image_error callback for resilient image parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,27 @@ loader = GenericLoader(
     blob_parser=PyMuPDF4LLMParser(),
 )
 ```
+### Resilient Image Parsing (Token Refresh)
+
+For long-running extraction tasks where authentication tokens for multimodal models might expire, you can use the `on_image_error` callback to refresh credentials and retry without failing the entire document:
+
+```python
+def handle_parsing_error(exception, parser, blob):
+    if "401" in str(exception) or "expired" in str(exception).lower():
+        # Logic to refresh your model's authentication
+        parser.model.refresh_auth_header() 
+        # Retry the parsing and return the content
+        return next(parser.lazy_parse(blob)).page_content
+    # Fallback or re-raise for other errors
+    raise exception
+
+loader = PyMuPDF4LLMLoader(
+    "large_document.pdf",
+    extract_images=True,
+    images_parser=my_llm_parser,
+    on_image_error=handle_parsing_error
+)
+```
 
 ## Development
 

--- a/langchain_pymupdf4llm/pymupdf4llm_loader.py
+++ b/langchain_pymupdf4llm/pymupdf4llm_loader.py
@@ -9,6 +9,7 @@ from pathlib import PurePath
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Iterator,
     Literal,
     Optional,
@@ -181,6 +182,9 @@ class PyMuPDF4LLMLoader(BasePDFLoader):
         pages_delimiter: str = _DEFAULT_PAGES_DELIMITER,
         extract_images: bool = False,
         images_parser: Optional[BaseBlobParser] = None,
+        on_image_error: Optional[
+            Callable[[Exception, "BaseBlobParser", "Blob"], str]
+        ] = None,
         use_layout: bool = False,
         **pymupdf4llm_kwargs,
     ) -> None:
@@ -199,6 +203,10 @@ class PyMuPDF4LLMLoader(BasePDFLoader):
                 `images_parser` to be set.
             images_parser: Optional image blob parser to process extracted images.
                 Required if `extract_images` is True.
+            on_image_error: A callback function to handle errors during image parsing.
+                Useful for refreshing authentication tokens during long-running
+                extraction tasks. Should accept (exception, parser, blob) and
+                return a string.
             use_layout: Whether to enable PyMuPDF layout extraction when supported by
                 the installed `pymupdf4llm` version.
             **pymupdf4llm_kwargs: Additional keyword arguments to pass directly to the
@@ -235,6 +243,7 @@ class PyMuPDF4LLMLoader(BasePDFLoader):
             pages_delimiter=pages_delimiter,
             extract_images=extract_images,
             images_parser=images_parser,
+            on_image_error=on_image_error,
             use_layout=use_layout,
             **pymupdf4llm_kwargs,
         )

--- a/langchain_pymupdf4llm/pymupdf4llm_parser.py
+++ b/langchain_pymupdf4llm/pymupdf4llm_parser.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from tempfile import TemporaryDirectory
 from typing import (
     Any,
+    Callable,
     Iterator,
     Literal,
     Optional,
@@ -149,6 +150,9 @@ class PyMuPDF4LLMParser(BaseBlobParser):
         mode: Literal["single", "page"] = "page",
         pages_delimiter: str = _DEFAULT_PAGES_DELIMITER,
         images_parser: Optional[BaseBlobParser] = None,
+        on_image_error: Optional[
+            Callable[[Exception, BaseBlobParser, Blob], str]
+        ] = None,
         use_layout: bool = False,
         **pymupdf4llm_kwargs,
     ) -> None:
@@ -164,6 +168,10 @@ class PyMuPDF4LLMParser(BaseBlobParser):
                 `images_parser` to be set.
             images_parser: Optional image blob parser to process extracted images.
                 Required if `extract_images` is True.
+            on_image_error: A callback function to handle errors during image parsing.
+                Useful for refreshing authentication tokens during long-running
+                extraction tasks. Should accept (exception, parser, blob) and
+                return a string.
             use_layout: Whether to enable PyMuPDF layout extraction when the installed
                 `pymupdf4llm` version exposes `use_layout()`.
             **pymupdf4llm_kwargs: Additional keyword arguments to pass directly to the
@@ -233,6 +241,7 @@ class PyMuPDF4LLMParser(BaseBlobParser):
         self.password = password
         self.extract_images = extract_images
         self.images_parser = images_parser
+        self.on_image_error = on_image_error
         self.use_layout = use_layout
         self.pymupdf4llm_kwargs = pymupdf4llm_kwargs
 
@@ -341,7 +350,24 @@ class PyMuPDF4LLMParser(BaseBlobParser):
                     # Check if the image file actually exists before processing
                     if os.path.exists(img_path):
                         blob = Blob.from_path(img_path)
-                        image_text = next(self.images_parser.lazy_parse(blob)).page_content
+                        try:
+                            image_text = next(
+                                self.images_parser.lazy_parse(blob)
+                            ).page_content
+                        except Exception as e:
+                            if self.on_image_error:
+                                try:
+                                    # Trigger callback for recovery or fallback text
+                                    image_text = self.on_image_error(
+                                        e, self.images_parser, blob
+                                    )
+                                except Exception as callback_err:
+                                    logger.error(
+                                        f"Error in on_image_error callback: {callback_err}"
+                                    )
+                                    raise callback_err
+                            else:
+                                raise e
                         image_text = image_text.replace("]", r"\\]")
                         img_md = f"![{image_text}](#)"
                         page_content_md = page_content_md.replace(f"![]({img_path})", img_md)


### PR DESCRIPTION
- Introduced `on_image_error` parameter to PyMuPDF4LLMLoader and Parser.
- Allows handling of image parsing exceptions (e.g., token expiration).
- Updated docstrings and README with usage examples for token refresh.
- Wrapped image parsing logic in try-except to support user-defined recovery.